### PR TITLE
ステージング環境と本番環境、両方でMigrationが実行出来るようにする

### DIFF
--- a/01_push_ecr_local.sh
+++ b/01_push_ecr_local.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if [ "$1" == "" ] || ([ "$1" != "stg" ] && [ "$1" != "prod" ])
+then
+  echo  "対象の環境を指定してください。stg, prod のみ指定できます。"
+  exit 1
+fi
+
+env="$1"
+repository=${env}-lgtm-cat-migration
+
+aws ecr get-login-password --profile lgtm-cat --region ap-northeast-1 | docker login --username AWS --password-stdin "${ACCOUNT_ID}".dkr.ecr.ap-northeast-1.amazonaws.com/"${repository}"
+
+docker build -t "${ACCOUNT_ID}".dkr.ecr.ap-northeast-1.amazonaws.com/${repository}:latest -f docker/migrate/Dockerfile .
+docker push "${ACCOUNT_ID}".dkr.ecr.ap-northeast-1.amazonaws.com/${repository}:latest

--- a/02_create_ecs_task_local.sh
+++ b/02_create_ecs_task_local.sh
@@ -1,44 +1,52 @@
 #!/usr/bin/env bash
 
-FAMILY_NAME=lgtm-cat-migration
+if [ "$1" == "" ] || ([ "$1" != "stg" ] && [ "$1" != "prod" ])
+then
+  echo  "対象の環境を指定してください。stg, prod のみ指定できます。"
+  exit 1
+fi
+
+env="$1"
+
+FAMILY_NAME=${env}-lgtm-cat-migration
 
 cat << EOF > ecs/task_definition.json
 {
-  "executionRoleArn": "arn:aws:iam::${ACCOUNT_ID}:role/lgtm-cat-migration-ecs-task-execution-role",
+  "executionRoleArn": "arn:aws:iam::${ACCOUNT_ID}:role/${env}-lgtm-cat-migration-ecs-task-execution-role",
   "containerDefinitions": [
     {
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "lgtm-cat-migration",
+          "awslogs-group": "${env}-lgtm-cat-migration",
           "awslogs-region": "ap-northeast-1",
           "awslogs-stream-prefix": "ecs"
         }
       },
-      "image": "${ACCOUNT_ID}.dkr.ecr.ap-northeast-1.amazonaws.com/lgtm-cat-migration",
+      "image": "${ACCOUNT_ID}.dkr.ecr.ap-northeast-1.amazonaws.com/${env}-lgtm-cat-migration",
       "name": "migration",
             "secrets": [
         {
           "name": "DB_HOSTNAME",
-          "valueFrom": "/lgtm-cat/migration/DB_HOSTNAME"
+          "valueFrom": "/${env}/lgtm-cat/migration/DB_HOSTNAME"
         },
         {
           "name": "DB_USERNAME",
-          "valueFrom": "/lgtm-cat/migration/DB_USERNAME"
+          "valueFrom": "/${env}/lgtm-cat/migration/DB_USERNAME"
         },
         {
           "name": "DB_NAME",
-          "valueFrom": "/lgtm-cat/migration/DB_NAME"
+          "valueFrom": "/${env}/lgtm-cat/migration/DB_NAME"
         },
         {
           "name": "DB_PASSWORD",
-          "valueFrom": "/lgtm-cat/migration/DB_PASSWORD"
+          "valueFrom": "/${env}/lgtm-cat/migration/DB_PASSWORD"
         }
       ]
     }
   ],
   "memory": "512",
-  "family": "lgtm-cat-migration",
+  "family": "${env}-lgtm-cat-migration",
   "requiresCompatibilities": [
     "FARGATE"
   ],

--- a/03_execute_ecs_task_local.sh
+++ b/03_execute_ecs_task_local.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 
-FAMILY_NAME=lgtm-cat-migration
+if [ "$1" == "" ] || ([ "$1" != "stg" ] && [ "$1" != "prod" ])
+then
+  echo  "対象の環境を指定してください。stg, prod のみ指定できます。"
+  exit 1
+fi
+
+env="$1"
+FAMILY_NAME=${env}-lgtm-cat-migration
+
+if [ "${env}" == "stg" ]
+then
+  SECURITY_GROUP_ID=${STG_SECURITY_GROUP_ID}
+else
+  SECURITY_GROUP_ID=${PROD_SECURITY_GROUP_ID}
+fi
 
 TASK_DEF_ARN=$(aws ecs list-task-definitions \
   --family-prefix "${FAMILY_NAME}" \
@@ -10,9 +24,8 @@ TASK_DEF_ARN=$(aws ecs list-task-definitions \
 
 NETWORK_CONFIG="awsvpcConfiguration={subnets=[${SUBNET_ID}],securityGroups=[${SECURITY_GROUP_ID}],assignPublicIp=ENABLED}"
 
-
 aws ecs run-task \
-  --cluster lgtm-cat-migration-cluster \
+  --cluster "${env}"-lgtm-cat-migration-cluster \
   --task-definition "${TASK_DEF_ARN}" \
   --launch-type FARGATE \
   --network-configuration "${NETWORK_CONFIG}" \

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ export DB_NAME=DB名
 
 # ECS実行用
 export SUBNET_ID=ECSタスクを実行するサブネットグループID
-export SECURITY_GROUP_ID=ECSタスクに設定するセキュリテイグループ
+export STG_SECURITY_GROUP_ID=STG環境用 ECSタスクに設定するセキュリテイグループ
+export PROD_SECURITY_GROUP_ID=PROD環境用 ECSタスクに設定するセキュリテイグループ
 export ACCOUNT_ID=AWSのアカウントID
 ```
 
@@ -125,7 +126,7 @@ GRANT ALL ON your_database.* TO 'your_user'@'%';
 Docker の新規作成時、変更時に実行します。
 
 ```bash
-./push_ecr_local.sh
+./01_push_ecr_local.sh <stg|prod>
 ```
 
 ### ECS タスクの定義の作成
@@ -133,7 +134,7 @@ Docker の新規作成時、変更時に実行します。
 ECS タスクの定義の新規作成時、変更時に実行します。
 
 ```bash
-./create_ecs_task_local.sh
+./02_create_ecs_task_local.sh <stg|prod>
 ```
 
 ### ECS タスクの実行
@@ -141,5 +142,5 @@ ECS タスクの定義の新規作成時、変更時に実行します。
 migration の際に実行します。
 
 ```bash
-./execute_ecs_task_local.sh
+./03_execute_ecs_task_local.sh <stg|prod>
 ```

--- a/push_ecr_local.sh
+++ b/push_ecr_local.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-repository=lgtm-cat-migration
-
-aws ecr get-login-password --profile lgtm-cat --region ap-northeast-1 | docker login --username AWS --password-stdin "${ACCOUNT_ID}".dkr.ecr.ap-northeast-1.amazonaws.com/${repository}
-
-docker build -t "${ACCOUNT_ID}".dkr.ecr.ap-northeast-1.amazonaws.com/${repository}:latest -f docker/migrate/Dockerfile .
-docker push "${ACCOUNT_ID}".dkr.ecr.ap-northeast-1.amazonaws.com/${repository}:latest


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-migration/issues/4

# 関連URL
Terraform 修正PR
https://github.com/nekochans/lgtm-cat-terraform/pull/54

# Doneの定義
ステージング環境と本番環境、両方でMigrationが実行出来ること

# 変更点概要
Terraform 修正PR https://github.com/nekochans/lgtm-cat-terraform/pull/54 で、STG・PROD環境用の migration 実行リソースを構築したので、そのリソース上で migration を実行できるように shell ファイルを修正した。

また、ファイル名に番号が振ってあったほうが、実行順序がわかりやすいかと思いファイル名も変更している。

# 補足情報
STG、PROD 環境にそれぞれ migration を実行できることを確認済み。
