### PR TITLE
ローカル開発用の MySQL を8.0にアップグレード

### DIFF
--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,3 +1,7 @@
-FROM mysql:5.7.32
+FROM mysql:8.0.23
 
 COPY ./docker/mysql/config/my.cnf /etc/mysql/conf.d/my.cnf
+
+RUN  set -eux && \
+  mkdir /var/log/mysql && \
+  chown mysql:mysql /var/log/mysql

--- a/docker/mysql/config/my.cnf
+++ b/docker/mysql/config/my.cnf
@@ -1,20 +1,31 @@
 [mysqld]
 character-set-server=utf8mb4
-collation-server=utf8mb4_bin
-skip-character-set-client-handshake
-default-storage-engine=InnoDB
-innodb_file_per_table=1
-innodb_large_prefix=1
-innodb_file_format=Barracuda
-innodb_default_row_format=DYNAMIC
-default_password_lifetime = 0
+collation-server=utf8mb4_0900_bin
+
+# デフォルト認証プラグイン
+default-authentication-plugin=mysql_native_password
+
+# タイムゾーン
+default-time-zone = SYSTEM
+log_timestamps = SYSTEM
+
+# エラーログ
+log-error = /var/log/mysql/error.log
+
+# クエリログ
+general_log = 1
+general_log_file = /var/log/mysql/query.log
+
+# スロークエリログ
 slow_query_log = 1
 long_query_time = 0.1
-slow_query_log_file = /var/log/mysql-slow-query.log
+slow_query_log_file = /var/log/mysql/slow.log
 
 [mysql]
-auto-rehash
 default-character-set = utf8mb4
+
+[client]
+default-character-set=utf8mb4
 
 [mysqldump]
 default-character-set = utf8mb4

--- a/docker/mysql/initial.sql
+++ b/docker/mysql/initial.sql
@@ -1,5 +1,6 @@
 -- 'local_lgtm_cat' というデータベースを作成
 -- 'local_lgtm_cat_user' というユーザー名のユーザーを作成
 -- データベース 'local_lgtm_cat' への権限を付与
-CREATE DATABASE IF NOT EXISTS local_lgtm_cat CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-GRANT ALL ON local_lgtm_cat.* TO `local_lgtm_cat_user`@`%` IDENTIFIED BY 'password';
+CREATE DATABASE IF NOT EXISTS local_lgtm_cat CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_bin;
+CREATE USER local_lgtm_cat_user@'%' IDENTIFIED WITH mysql_native_password BY 'password';
+GRANT ALL ON local_lgtm_cat.* TO 'local_lgtm_cat_user'@'%';

--- a/migrations/20210809235322_create_lgtm_images.up.sql
+++ b/migrations/20210809235322_create_lgtm_images.up.sql
@@ -7,4 +7,4 @@ CREATE TABLE `lgtm_images` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `uq_lgtm_images_01` (`filename`),
   KEY `idx_lgtm_images_01` (`path`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin ROW_FORMAT=DYNAMIC;


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-migration/issues/5

# Doneの定義
https://github.com/nekochans/lgtm-cat-migration/issues/5 の完了の定義が満たされていること

# 変更点概要
- ローカル開発用の Docker MySQL を8.0にアップグレード
- COLLATE を `utf8mb4_0900_bin`に変更
- Issueの補足情報に記載されているリポジトリを参考に `docker/mysql/config/my.cnf` を修正