### PR TITLE
CI で docker 起動する際のエラーを解消するために COPY のパスを変更

### DIFF
--- a/docker/migrate/Dockerfile
+++ b/docker/migrate/Dockerfile
@@ -2,10 +2,10 @@ FROM migrate/migrate:v4.14.1
 
 WORKDIR /opt/app
 
-COPY ../migrations ./migrations
-COPY ../Makefile ./
-COPY ../migrate_up.sh ./
-COPY ../migrate_down.sh ./
+COPY ./migrations ./migrations
+COPY ./Makefile ./
+COPY ./migrate_up.sh ./
+COPY ./migrate_down.sh ./
 
 RUN set -eux && \
   apk update && \


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-migration/issues/10

# Doneの定義
https://github.com/nekochans/lgtm-cat-migration/issues/10 の完了条件が満たされていること

# 変更点概要
CI の設定で GitHub Actions で、このリポジトリに定義してある docker-compose を利用して Docker を起動しようとしたところ下記のエラーが発生した。
https://github.com/nekochans/lgtm-cat-api/runs/6026009417?check_suite_focus=true
```
Step 3/8 : COPY ../migrations ./migrations
COPY failed: forbidden path outside the build context: ../migrations ()
Service 'migrate' failed to build : Build failed
Error: Process completed with exit code 1.
```

COPY のパスを変更することでエラーが解消した。
https://github.com/nekochans/lgtm-cat-api/runs/6026602308?check_suite_focus=true

# 補足情報
AWS ECS タスクの実行でも migration が実行できることも確認済み。
