### PR TITLE
CI 用の docker-compose-ci.yml を作成

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  migrate:
+    build:
+      context: .
+      dockerfile: docker/migrate/Dockerfile
+    command: 'tail -f /dev/null'
+    restart: always
+    environment:
+      DB_HOSTNAME: ${DB_HOSTNAME}
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_NAME: ${DB_NAME}
+    depends_on:
+      - mysql
+  mysql:
+    build:
+      context: .
+      dockerfile: docker/mysql/Dockerfile
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+    ports:
+      - '3306:3306'
+    volumes:
+      - ./docker/mysql:/docker-entrypoint-initdb.d


### PR DESCRIPTION
# issueURL
なし

# 関連URL
https://github.com/nekochans/lgtm-cat-api/pull/43 対応で必要

# 変更点概要
CI 用の `docker-compose-ci.yml` を作成。
ローカル環境用の `docker-compose.yml`をコピーし、volume mount の部分のみ削除している。
経緯は、https://github.com/nekochans/lgtm-cat-api/pull/43 を参照。