### PR TITLE
docker-compose.yml にnetworkを設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ created ./migrations/20210807151547_create_users.down.sql
 
 Migration のロールバックを行う際は `./migrate_down.sh` を実行します。
 
+ローカル開発環境の場合、migrate コンテナ上で実行する必要があります。
+
 ## AWS 上での Migration 実行方法
 
 ECSタスクで migration を実行します。

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -19,7 +19,7 @@ services:
       context: .
       dockerfile: docker/mysql/Dockerfile
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
     ports:
       - '3306:3306'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: ${DB_NAME}
+    networks:
+      - lgtm-cat
     depends_on:
       - mysql
   mysql:
@@ -19,9 +21,14 @@ services:
       context: .
       dockerfile: docker/mysql/Dockerfile
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
     ports:
       - '3306:3306'
     volumes:
       - ./data:/var/lib/mysql
       - ./docker/mysql:/docker-entrypoint-initdb.d
+    networks:
+      - lgtm-cat
+networks:
+  lgtm-cat:
+    external: true


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-migration/issues/13

# 関連URL
lgtm-cat-api の PR
https://github.com/nekochans/lgtm-cat-api/pull/48

# Doneの定義
https://github.com/nekochans/lgtm-cat-migration/issues/13 の完了の定義が満たされていること

# 変更点概要
- [lgtm-cat-api 開発用のDocker環境からMySQLコンテナに接続できるようにdocker-compose.yml にnetworkを設定](https://github.com/nekochans/lgtm-cat-migration/commit/ad15eda300dff37fcc92714330dcd01d7430ed50) 
- Issueとは関係ないが下記の変更も行なった
    - [migration 実行方法の説明がわかりにくかったので、説明を追加](https://github.com/nekochans/lgtm-cat-migration/commit/d7188ac4ceaf008d5ff6bc47bea626efac855b2f)