### PR TITLE
M1 チップ でも起動できるように MySQL の Docker を最新バージョンに変更

### DIFF
--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.0.23
+FROM mysql:8.0.31
 
 COPY ./docker/mysql/config/my.cnf /etc/mysql/conf.d/my.cnf
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-migration/issues/15

# Doneの定義
https://github.com/nekochans/lgtm-cat-migration/issues/15 の完了条件を満たしていること

# 変更点概要
M1 チップ でも起動できるように MySQL の Docker を最新バージョンに変更。
下記に `8.0.31` は arm64v8 に対応されていると記載されている。
https://github.com/docker-library/official-images/blob/master/library/mysql 